### PR TITLE
Package Safety Check

### DIFF
--- a/src/Scriptcs/PackageAssemblyResolver.cs
+++ b/src/Scriptcs/PackageAssemblyResolver.cs
@@ -21,6 +21,12 @@ namespace Scriptcs
         public IEnumerable<string> GetAssemblyNames()
         {
             var packageDir = _fileSystem.CurrentDirectory + @"\" + "packages";
+            
+            if (!Directory.Exists(packageDir))
+            {
+                return new List<string>();
+            }
+            
             var folders = new List<string>();
             var files = new List<string>();
             foreach (var file in Directory.EnumerateFiles(packageDir, @"*.dll", SearchOption.AllDirectories))


### PR DESCRIPTION
Allowing for usage of scriptcs without nuget packages on the local path.  This allows to use scriptcs without any complex dependencies.
